### PR TITLE
Add support for Attribute inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ method_has_attribute(Foo::class, MethodAttribute::class, 'bar'); // true
 property_has_attribute(Foo::class, PropertyAttribute::class, 'baz'); // true
 ```
 
+It also supports Attribute inheritance:
+
+```php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class ClassAttributeInterface {}
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class ChildClassAttribute extends ClassAttributeInterface {}
+
+#[ChildClassAttribute]
+class Foo {}
+
+class_has_attribute(Baz::class, [ClassAttributeInterface::class]); // true
+```
+
 ## Credits
 
 This package is based on an idea from [lyrixx](https://github.com/lyrixx), and was implemented by [welcomattic](https://github.com/welcomattic) and [Korbeil](https://github.com/Korbeil).

--- a/src/HasAttribute.php
+++ b/src/HasAttribute.php
@@ -67,7 +67,7 @@ final class HasAttribute
     {
         $foundAttributes = [];
         foreach ($attributes as $attribute) {
-            if ($reflection->getAttributes($attribute)[0] ?? false) {
+            if ($reflection->getAttributes($attribute, \ReflectionAttribute::IS_INSTANCEOF)[0] ?? false) {
                 $foundAttributes[] = $attribute;
             }
         }

--- a/tests/HasAttributeTest.php
+++ b/tests/HasAttributeTest.php
@@ -24,6 +24,8 @@ class HasAttributeTest extends TestCase
         $this->assertTrue(class_has_attribute(Bar::class, [ClassAttribute::class], HasAttributeMode::ATTRIBUTES_ANY_OF));
         $this->assertTrue(class_has_attribute(Bar::class, [ClassAttribute::class, AnotherClassAttribute::class], HasAttributeMode::ATTRIBUTES_ANY_OF));
         $this->assertFalse(class_has_attribute(Bar::class, [AnotherAnotherClassAttribute::class], HasAttributeMode::ATTRIBUTES_ANY_OF));
+
+        $this->assertTrue(class_has_attribute(Baz::class, [ClassAttributeInterface::class]));
     }
 
     public function testMethodHasAttribute(): void
@@ -77,6 +79,11 @@ class AnotherClassAttribute {}
 #[\Attribute(\Attribute::TARGET_CLASS)]
 class AnotherAnotherClassAttribute {}
 
+class ClassAttributeInterface {}
+
+#[\Attribute(\Attribute::TARGET_CLASS)]
+class ChildClassAttribute extends ClassAttributeInterface {}
+
 #[\Attribute(\Attribute::TARGET_METHOD)]
 class MethodAttribute {}
 
@@ -123,3 +130,6 @@ class Foo
 
 #[ClassAttribute]
 class Bar {}
+
+#[ChildClassAttribute]
+class Baz {}


### PR DESCRIPTION
Example:

```php
#[\Attribute(\Attribute::TARGET_CLASS)]
class ClassAttributeInterface {}

#[\Attribute(\Attribute::TARGET_CLASS)]
class ChildClassAttribute extends ClassAttributeInterface {}

#[ChildClassAttribute]
class Foo {}

class_has_attribute(Baz::class, [ClassAttributeInterface::class]); // true
```

Thank you @stof :+1: 